### PR TITLE
Revert "Fix build docs with sphinx and m2r"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,7 @@
 # Changelog
 
-## v0.3.2
-* DOC: update m2r from a [fork](https://github.com/crossnox/m2r) to support sphinx >= 3
-
 ## v0.3.1
+
 * Add `hidden=True` to `_GroupTitleFakeOption` as a temporary workaroud for issue [#4](https://github.com/click-contrib/click-option-group/issues/4)
 
 ## v0.3.0

--- a/click_option_group/_version.py
+++ b/click_option_group/_version.py
@@ -1,3 +1,3 @@
 # -*- coding: utf-8 -*-
 
-__version__ = '0.3.2'
+__version__ = '0.3.1'

--- a/setup.py
+++ b/setup.py
@@ -33,11 +33,7 @@ setup(
         'Click>=7.0,<8',
     ],
     extras_require={
-        'docs': [
-            'sphinx>=2.3',
-            'Pallets-Sphinx-Themes',
-            'm2r @ git+https://github.com/crossnox/m2r@dev#egg=m2r',
-        ],
+        'docs': ['sphinx>=2.3', 'Pallets-Sphinx-Themes', 'm2r'],
         'tests': ['pytest'],
     },
     url='https://github.com/click-contrib/click-option-group',


### PR DESCRIPTION
Reverts click-contrib/click-option-group#6

Because we cannot upload wheel to PyPI with direct link to dependency

```
HTTPError: 400 Client Error: Invalid value for requires_dist. Error: Can't have direct dependency: "m2r @ git+https://github.com/crossnox/m2r@dev#egg=m2
r ; extra == 'docs'"
```
