### PR TITLE
Support multi-layer wrapped functions.

### DIFF
--- a/click_option_group/_core.py
+++ b/click_option_group/_core.py
@@ -12,6 +12,7 @@ from ._helpers import (
     get_callback_and_params,
     get_fake_option_name,
     raise_mixing_decorators_error,
+    resolve_wrappers
 )
 
 
@@ -182,7 +183,7 @@ class OptionGroup:
     def get_options(self, ctx: click.Context) -> ty.Dict[str, GroupedOption]:
         """Returns the dictionary with group options
         """
-        return self._options.get(ctx.command.callback, {})
+        return self._options.get(resolve_wrappers(ctx.command.callback), {})
 
     def get_option_names(self, ctx: click.Context) -> ty.List[str]:
         """Returns the list with option names ordered by addition in the group

--- a/click_option_group/_helpers.py
+++ b/click_option_group/_helpers.py
@@ -23,6 +23,7 @@ def get_callback_and_params(func) -> ty.Tuple[abc.Callable, ty.List[click.Option
     else:
         params = getattr(func, '__click_params__', [])
 
+    func = resolve_wrappers(func)
     return func, params
 
 
@@ -37,3 +38,8 @@ def raise_mixing_decorators_error(wrong_option: click.Option, callback: abc.Call
         "Grouped options must not be mixed with regular parameters while adding by decorator. "
         f"Check decorator position for {error_hint} option in '{callback.__name__}'."
     ))
+
+
+def resolve_wrappers(f):
+    """Get the underlying function behind any level of function wrappers."""
+    return resolve_wrappers(f.__wrapped__) if hasattr(f, "__wrapped__") else f


### PR DESCRIPTION
# Problem Statement

I'm trying to implement a pattern where you can combine multiple config options to produce a single variable passed to a decorated function. For example, say I have an object `z` that takes lots of interesting config parameters, but implementation of my function ultimately only cares about `z` and I want `click` to handle all of the details of handling arguments about how to make a `z` without me having to make sub-commands or put processing logic inside of my decorated function. Also, I wan to be able to reuse that decorator to make lots of other interesting scripts that have the same interface.

The ultimate goal is being able to allow users to attach a decorator to their commands and instantly get an extension to their CLI that produces a single interesting argument to them. I haven't found a way to use the context object passing in `click` to accomplish this since it seems to suggest that I add sub-commands for every new decorator I want to make. I have, however, found a nice way to do this with custom decorators.

The following example works just fine within standard `click` (i.e. I get all of the options I want available), but I seem to be unable to use `click-option-group` the way I want. The simplest way to demonstrate what I'm trying to do and the problem that I have is with the following example:

```python
from functools import wraps
import click
from click.testing import CliRunner
from click_option_group import optgroup

def make_z():
    """A unified option interface for making a `z`."""
    def decorator(f):
        @optgroup.group("Group xyz")
        @optgroup.option('-x', type=int)
        @optgroup.option('-y', type=int)
        @wraps(f)
        def new_func(*args, x=0, y=0, **kwargs):
            # Here we handle every detail about how to make a `z` from the given options
            f(*args, z=x + y, **kwargs)
        return new_func
    return decorator

def make_c():
    """A unified option interface for making a `c`."""
    def decorator(f):
        @optgroup.group("Group abc")
        @optgroup.option('-a', type=int)
        @optgroup.option('-b', type=int)
        @wraps(f)
        def new_func(*args, a=0, b=0, **kwargs):
            # Here we do the same, but for another object `c` (and many others to come)
            f(*args, c=a * b, **kwargs)
        return new_func
    return decorator

# Here I want to create a script that has a commen UI to make a `z`.
# I want to reuse a common set of options for how to make a `z` and don't want
# to sweat the details. Also, I've decided that I also want a `c` for this script.
@click.command()
@make_z()
@make_c()
def f(z, c):
    print(z, c)
    
# Test
cli = CliRunner()
print(cli.invoke(f, ['--help']))
```

With the current version of `click-option-group`, I get the following output:

```
Usage: f [OPTIONS]

Options:
  Group xyz: 
    -x INTEGER
    -y INTEGER
    -a INTEGER
    -b INTEGER
  --help        Show this message and exit.
```

What I would like to see is:
```
sage: f [OPTIONS]

Options:
  Group xyz: 
    -x INTEGER
    -y INTEGER
  Group abc: 
    -a INTEGER
    -b INTEGER
  --help        Show this message and exit.
```

# Root Cause

After some debugging, I discovered the issues had to do with these lines https://github.com/click-contrib/click-option-group/blob/401ba132c5a8cc8b7c4ca0d49e47860053bbd3f2/click_option_group/_core.py#L142-L143

I can comment this out and I get what I want, but I knew that wasn't the right approach to fix this.

Because I used `functools.wraps` in my approach the `ctx.callback` was not pointing to the same "version" of `f` for all layers of option groups (i.e. the first option group in the call chain has the "original" funciton `f`, but after the `make_c` decorator, the function used in the `_options` dictionary of the `OptionGroup` is the `new_func` that gets created in `make_c`.

Therefore, when we finally invoke the click command, the `ctx.callback` ends up with the outermost function wrapper, and any callers of `OptionGroup.get_options` don't see the options and option groups that were attached to the inner "versions" of `f` that were wrapped because they use that function directly to index the`_options` dictionary.

# Solution

In order to support this usage pattern, I propose that rather than using the callback function directly to index into the supporting dictionaries, that we instead resolve the wrappers down to the lowest function in a string of wrappers--this guarantees that no matter how many times I wrap a function to coalesce arguments, we're always anchoring the same function as we build up option grups.