### PR TITLE
v0.5.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v0.5.2 (28.11.2020)
+
+* Do not use default option group name. An empty group name will not be displayed
+* Slightly edited error messages
+* All arguments except `name` in `optgroup` decorator must be keyword-only
+
 ## v0.5.1 (14.06.2020)
 
 * Fix incompatibility with autocomplete: out of the box Click completion and click-repl (Issue [#14](https://github.com/click-contrib/click-option-group/issues/14))

--- a/click_option_group/__init__.py
+++ b/click_option_group/__init__.py
@@ -5,7 +5,7 @@ click-option-group
 
 Option groups missing in Click
 
-:copyright: © 2019 by Eugene Prilepin
+:copyright: © 2019-2020 by Eugene Prilepin
 :license: BSD, see LICENSE for more details.
 """
 

--- a/click_option_group/_core.py
+++ b/click_option_group/_core.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
-import typing as ty
+from typing import Optional, List, Tuple, Dict, Set
+
 import collections
 import weakref
 import inspect
@@ -91,8 +92,8 @@ class OptionGroup:
     :param help: the group help text or None
     """
 
-    def __init__(self, name: ty.Optional[str] = None, *,
-                 hidden=False, help: ty.Optional[str] = None) -> None:  # noqa
+    def __init__(self, name: Optional[str] = None, *,
+                 hidden=False, help: Optional[str] = None) -> None:  # noqa
         self._name = name if name else ''
         self._help = inspect.cleandoc(help if help else '')
         self._hidden = hidden
@@ -117,13 +118,13 @@ class OptionGroup:
         return self._help
 
     @property
-    def name_extra(self) -> ty.List[str]:
+    def name_extra(self) -> List[str]:
         """Returns extra name attributes for the group
         """
         return []
 
     @property
-    def forbidden_option_attrs(self) -> ty.List[str]:
+    def forbidden_option_attrs(self) -> List[str]:
         """Returns the list of forbidden option attributes for the group
         """
         return []
@@ -140,7 +141,7 @@ class OptionGroup:
         option_names = '|'.join(self.get_option_names(ctx))
         return f'({option_names})'
 
-    def get_help_record(self, ctx: click.Context) -> ty.Optional[ty.Tuple[str, str]]:
+    def get_help_record(self, ctx: click.Context) -> Optional[Tuple[str, str]]:
         """Returns the help record for the group
 
         :param ctx: Click Context object
@@ -186,17 +187,17 @@ class OptionGroup:
 
         return decorator
 
-    def get_options(self, ctx: click.Context) -> ty.Dict[str, GroupedOption]:
+    def get_options(self, ctx: click.Context) -> Dict[str, GroupedOption]:
         """Returns the dictionary with group options
         """
         return self._options.get(resolve_wrappers(ctx.command.callback), {})
 
-    def get_option_names(self, ctx: click.Context) -> ty.List[str]:
+    def get_option_names(self, ctx: click.Context) -> List[str]:
         """Returns the list with option names ordered by addition in the group
         """
         return list(reversed(list(self.get_options(ctx))))
 
-    def get_error_hint(self, ctx, option_names: ty.Optional[ty.Set[str]] = None) -> str:
+    def get_error_hint(self, ctx, option_names: Optional[Set[str]] = None) -> str:
         options = self.get_options(ctx)
         text = ''
 
@@ -258,11 +259,11 @@ class RequiredAnyOptionGroup(OptionGroup):
     """
 
     @property
-    def forbidden_option_attrs(self) -> ty.List[str]:
+    def forbidden_option_attrs(self) -> List[str]:
         return ['required']
 
     @property
-    def name_extra(self) -> ty.List[str]:
+    def name_extra(self) -> List[str]:
         return super().name_extra + ['required_any']
 
     def handle_parse_result(self, option: GroupedOption, ctx: click.Context, opts: dict) -> None:
@@ -296,11 +297,11 @@ class RequiredAllOptionGroup(OptionGroup):
     """
 
     @property
-    def forbidden_option_attrs(self) -> ty.List[str]:
+    def forbidden_option_attrs(self) -> List[str]:
         return ['required', 'hidden']
 
     @property
-    def name_extra(self) -> ty.List[str]:
+    def name_extra(self) -> List[str]:
         return super().name_extra + ['required_all']
 
     def handle_parse_result(self, option: GroupedOption, ctx: click.Context, opts: dict) -> None:
@@ -325,11 +326,11 @@ class MutuallyExclusiveOptionGroup(OptionGroup):
     """
 
     @property
-    def forbidden_option_attrs(self) -> ty.List[str]:
+    def forbidden_option_attrs(self) -> List[str]:
         return ['required']
 
     @property
-    def name_extra(self) -> ty.List[str]:
+    def name_extra(self) -> List[str]:
         return super().name_extra + ['mutually_exclusive']
 
     def handle_parse_result(self, option: GroupedOption, ctx: click.Context, opts: dict) -> None:
@@ -356,7 +357,7 @@ class RequiredMutuallyExclusiveOptionGroup(MutuallyExclusiveOptionGroup):
     """
 
     @property
-    def name_extra(self) -> ty.List[str]:
+    def name_extra(self) -> List[str]:
         return super().name_extra + ['required']
 
     def handle_parse_result(self, option: GroupedOption, ctx: click.Context, opts: dict) -> None:
@@ -384,11 +385,11 @@ class AllOptionGroup(OptionGroup):
     """
 
     @property
-    def forbidden_option_attrs(self) -> ty.List[str]:
+    def forbidden_option_attrs(self) -> List[str]:
         return ['required', 'hidden']
 
     @property
-    def name_extra(self) -> ty.List[str]:
+    def name_extra(self) -> List[str]:
         return super().name_extra + ['all_or_none']
 
     def handle_parse_result(self, option: GroupedOption, ctx: click.Context, opts: dict) -> None:

--- a/click_option_group/_core.py
+++ b/click_option_group/_core.py
@@ -270,17 +270,23 @@ class RequiredAnyOptionGroup(OptionGroup):
             return
 
         if all(o.hidden for o in self.get_options(ctx).values()):
-            error_text = (f'Need at least one non-hidden option in RequiredAnyOptionGroup '
-                          f'"{self.get_default_name(ctx)}".')
-            raise TypeError(error_text)
+            cls_name = self.__class__.__name__
+            group_name = self.get_default_name(ctx)
+
+            raise TypeError(
+                f"Need at least one non-hidden option in group '{group_name}' ('{cls_name}')."
+            )
 
         option_names = set(self.get_options(ctx))
 
         if not option_names.intersection(opts):
-            error_text = f'Missing one of the required options from "{self.get_default_name(ctx)}" option group:'
-            error_text += f'\n{self.get_error_hint(ctx)}'
+            group_name = self.get_default_name(ctx)
+            option_info = self.get_error_hint(ctx)
 
-            raise click.UsageError(error_text, ctx=ctx)
+            raise click.UsageError(
+                f"At least one of the following options from '{group_name}' group is required:\n{option_info}",
+                ctx=ctx
+            )
 
 
 class RequiredAllOptionGroup(OptionGroup):
@@ -301,12 +307,14 @@ class RequiredAllOptionGroup(OptionGroup):
         option_names = set(self.get_options(ctx))
 
         if not option_names.issubset(opts):
+            group_name = self.get_default_name(ctx)
             required_names = option_names.difference(option_names.intersection(opts))
+            option_info = self.get_error_hint(ctx, required_names)
 
-            error_text = f'Missing required options from "{self.get_default_name(ctx)}" option group:'
-            error_text += f'\n{self.get_error_hint(ctx, required_names)}'
-
-            raise click.UsageError(error_text, ctx=ctx)
+            raise click.UsageError(
+                f"Missing required options from '{group_name}' group:\n{option_info}",
+                ctx=ctx
+            )
 
 
 class MutuallyExclusiveOptionGroup(OptionGroup):
@@ -330,9 +338,14 @@ class MutuallyExclusiveOptionGroup(OptionGroup):
         given_option_count = len(given_option_names)
 
         if given_option_count > 1:
-            error_text = 'The given mutually exclusive options cannot be used at the same time:'
-            error_text += f'\n{self.get_error_hint(ctx, given_option_names)}'
-            raise click.UsageError(error_text, ctx=ctx)
+            group_name = self.get_default_name(ctx)
+            option_info = self.get_error_hint(ctx, given_option_names)
+
+            raise click.UsageError(
+                f"Mutually exclusive options from '{group_name}' group "
+                f"cannot be used at the same time:\n{option_info}",
+                ctx=ctx
+            )
 
 
 class RequiredMutuallyExclusiveOptionGroup(MutuallyExclusiveOptionGroup):
@@ -353,17 +366,21 @@ class RequiredMutuallyExclusiveOptionGroup(MutuallyExclusiveOptionGroup):
         given_option_names = option_names.intersection(opts)
 
         if len(given_option_names) == 0:
-            error_text = ('Missing one of the required mutually exclusive options from '
-                          f'"{self.get_default_name(ctx)}" option group:')
-            error_text += f'\n{self.get_error_hint(ctx)}'
-            raise click.UsageError(error_text, ctx=ctx)
+            group_name = self.get_default_name(ctx)
+            option_info = self.get_error_hint(ctx)
+
+            raise click.UsageError(
+                "Missing one of the required mutually exclusive options from "
+                f"'{group_name}' option group:\n{option_info}",
+                ctx=ctx
+            )
 
 
 class AllOptionGroup(OptionGroup):
     """Option group with required all/none options of this group
 
     `AllOptionGroup` defines the behavior:
-    - All options from the group must be set or None must be set.
+        - All options from the group must be set or None must be set
     """
 
     @property
@@ -378,9 +395,11 @@ class AllOptionGroup(OptionGroup):
         option_names = set(self.get_options(ctx))
 
         if not option_names.isdisjoint(opts) and option_names.intersection(opts) != option_names:
-            error_text = f'All options should be specified or None should be specified from the group ' \
-                         f'"{self.get_default_name(ctx)}".'
-            error_text += f'\nMissing required options from "{self.get_default_name(ctx)}" option group.'
-            error_text += f'\n{self.get_error_hint(ctx)}'
-            error_text += '\n'
-            raise click.UsageError(error_text, ctx=ctx)
+            group_name = self.get_default_name(ctx)
+            option_info = self.get_error_hint(ctx)
+
+            raise click.UsageError(
+                "All options should be specified or none should be specified from the group "
+                f"'{group_name}'. Missing required options:\n{option_info}",
+                ctx=ctx
+            )

--- a/click_option_group/_decorators.py
+++ b/click_option_group/_decorators.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
-import typing as ty
+from typing import Optional, NamedTuple, List, Tuple, Dict, Any, Type
+
 import collections.abc as abc
 import collections
 import warnings
@@ -15,9 +16,9 @@ from ._helpers import (
 )
 
 
-class OptionStackItem(ty.NamedTuple):
-    param_decls: ty.Tuple[str, ...]
-    attrs: ty.Dict[str, ty.Any]
+class OptionStackItem(NamedTuple):
+    param_decls: Tuple[str, ...]
+    attrs: Dict[str, Any]
     param_count: int
 
 
@@ -61,21 +62,24 @@ class _OptGroup:
     """
 
     def __init__(self) -> None:
-        self._decorating_state: ty.Dict[abc.Callable, ty.List[OptionStackItem]] = collections.defaultdict(list)
-        self._not_attached_options: ty.Dict[abc.Callable, ty.List[click.Option]] = collections.defaultdict(list)
+        self._decorating_state: Dict[abc.Callable, List[OptionStackItem]] = collections.defaultdict(list)
+        self._not_attached_options: Dict[abc.Callable, List[click.Option]] = collections.defaultdict(list)
         self._outer_frame_index = 1
 
-    def __call__(self, name: ty.Optional[str] = None, help: ty.Optional[str] = None,
-                 cls: ty.Optional[ty.Type[OptionGroup]] = None, **attrs):
+    def __call__(self,
+                 name: Optional[str] = None,
+                 help: Optional[str] = None,
+                 cls: Optional[Type[OptionGroup]] = None, **attrs):
         try:
             self._outer_frame_index = 2
             return self.group(name, cls=cls, help=help, **attrs)
         finally:
             self._outer_frame_index = 1
 
-    def group(self, name: ty.Optional[str] = None, *,
-              cls: ty.Optional[ty.Type[OptionGroup]] = None,
-              help: ty.Optional[str] = None, **attrs):
+    def group(self,
+              name: Optional[str] = None, *,
+              cls: Optional[Type[OptionGroup]] = None,
+              help: Optional[str] = None, **attrs):
         """The decorator creates a new group and collects its options
 
         Creates the option group and registers all grouped options

--- a/click_option_group/_decorators.py
+++ b/click_option_group/_decorators.py
@@ -67,27 +67,37 @@ class _OptGroup:
         self._outer_frame_index = 1
 
     def __call__(self,
-                 name: Optional[str] = None,
+                 name: Optional[str] = None, *,
                  help: Optional[str] = None,
                  cls: Optional[Type[OptionGroup]] = None, **attrs):
+        """Creates a new group and collects its options
+
+        Creates the option group and registers all grouped options
+        which were added by `option` decorator.
+
+        :param name: Group name or None for deault name
+        :param help: Group help or None for empty help
+        :param cls: Option group class that should be inherited from `OptionGroup` class
+        :param attrs: Additional parameters of option group class
+        """
         try:
             self._outer_frame_index = 2
-            return self.group(name, cls=cls, help=help, **attrs)
+            return self.group(name, help=help, cls=cls, **attrs)
         finally:
             self._outer_frame_index = 1
 
     def group(self,
               name: Optional[str] = None, *,
-              cls: Optional[Type[OptionGroup]] = None,
-              help: Optional[str] = None, **attrs):
+              help: Optional[str] = None,
+              cls: Optional[Type[OptionGroup]] = None, **attrs):
         """The decorator creates a new group and collects its options
 
         Creates the option group and registers all grouped options
         which were added by `option` decorator.
 
         :param name: Group name or None for deault name
-        :param cls: Option group class that should be inherited from `OptionGroup` class
         :param help: Group help or None for empty help
+        :param cls: Option group class that should be inherited from `OptionGroup` class
         :param attrs: Additional parameters of option group class
         """
 

--- a/click_option_group/_helpers.py
+++ b/click_option_group/_helpers.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
-import typing as ty
+from typing import List, Tuple
+
 import collections.abc as abc
 import random
 import string
@@ -11,7 +12,7 @@ import click
 FAKE_OPT_NAME_LEN = 30
 
 
-def get_callback_and_params(func) -> ty.Tuple[abc.Callable, ty.List[click.Option]]:
+def get_callback_and_params(func) -> Tuple[abc.Callable, List[click.Option]]:
     """Returns callback function and its parameters list
 
     :param func: decorated function or click Command

--- a/click_option_group/_version.py
+++ b/click_option_group/_version.py
@@ -1,3 +1,3 @@
 # -*- coding: utf-8 -*-
 
-__version__ = '0.5.1'
+__version__ = '0.5.2'

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -22,7 +22,7 @@ from click_option_group import __version__  # noqa
 # -- Project information -----------------------------------------------------
 
 project = 'click-option-group'
-copyright = '2020, Eugene Prilepin'
+copyright = '2019-2020, Eugene Prilepin'
 author = 'Eugene Prilepin'
 
 # The full version, including alpha/beta/rc tags

--- a/tests/test_click_option_group.py
+++ b/tests/test_click_option_group.py
@@ -47,25 +47,24 @@ def test_basic_functionality_first_api(runner):
     assert 'foo1,bar1,foo2,bar2' in result.output
 
 
-def test_default_group_name(runner):
+def test_noname_group(runner):
     @click.command()
     @optgroup()
     @optgroup.option('--foo')
-    def cli(foo, bar):
+    def cli(foo):
         pass
 
     result = runner.invoke(cli, ['--help'])
-    assert '(foo):' in result.output
+    assert 'Options:\n    --foo' in result.output
 
     @click.command()
-    @optgroup()
+    @optgroup(help='Group description')
     @optgroup.option('--foo')
-    @optgroup.option('--bar')
-    def cli(foo, bar):
+    def cli(foo):
         pass
 
     result = runner.invoke(cli, ['--help'])
-    assert '(foo|bar):' in result.output
+    assert 'Group description' in result.output
 
 
 def test_mix_decl_first_api():
@@ -303,7 +302,8 @@ def test_all_option_group(runner):
     result = runner.invoke(cli, ['--foo', 'foo'])
     assert result.exception
     assert result.exit_code == 2
-    assert 'All options should be specified or none should be specified' in result.output
+    assert 'All options from' in result.output
+    assert 'should be specified or none should be specified' in result.output
     assert '--foo' in result.output
     assert '--bar' in result.output
 
@@ -565,7 +565,7 @@ def test_subcommand_second_api(runner):
 
 
 def test_group_context_second_api(runner):
-    group = OptionGroup()
+    group = OptionGroup('My Group')
 
     @click.command()
     @group.option('--foo1')
@@ -581,13 +581,13 @@ def test_group_context_second_api(runner):
 
     result = runner.invoke(cli1, ['--help'])
     assert not result.exception
-    assert '(foo1|bar1):' in result.output
+    assert 'My Group:' in result.output
     assert '--foo1' in result.output
     assert '--bar1' in result.output
 
     result = runner.invoke(cli2, ['--help'])
     assert not result.exception
-    assert '(foo2|bar2):' in result.output
+    assert 'My Group:' in result.output
     assert '--foo2' in result.output
     assert '--bar2' in result.output
 

--- a/tests/test_click_option_group.py
+++ b/tests/test_click_option_group.py
@@ -263,7 +263,7 @@ def test_required_any_option_group(runner):
     result = runner.invoke(cli, [])
     assert result.exception
     assert result.exit_code == 2
-    assert 'Missing one of the required options' in result.output
+    assert 'At least one of the following options' in result.output
     assert '--foo' in result.output
     assert '--bar' in result.output
 
@@ -303,7 +303,7 @@ def test_all_option_group(runner):
     result = runner.invoke(cli, ['--foo', 'foo'])
     assert result.exception
     assert result.exit_code == 2
-    assert 'All options should be specified or None should be specified from the group' in result.output
+    assert 'All options should be specified or none should be specified' in result.output
     assert '--foo' in result.output
     assert '--bar' in result.output
 
@@ -377,21 +377,24 @@ def test_mutually_exclusive_option_group(runner):
     result = runner.invoke(cli, ['--foo', 'foo', '--bar', 'bar'])
     assert result.exception
     assert result.exit_code == 2
-    assert 'The given mutually exclusive options cannot be used at the same time' in result.output
+    assert 'Mutually exclusive options from' in result.output
+    assert 'cannot be used at the same time' in result.output
     assert '--foo' in result.output
     assert '--bar' in result.output
 
     result = runner.invoke(cli, ['--foo', 'foo', '--spam', 'spam'])
     assert result.exception
     assert result.exit_code == 2
-    assert 'The given mutually exclusive options cannot be used at the same time' in result.output
+    assert 'Mutually exclusive options from' in result.output
+    assert 'cannot be used at the same time' in result.output
     assert '--foo' in result.output
     assert '--spam' in result.output
 
     result = runner.invoke(cli, ['--bar', 'bar', '--spam', 'spam'])
     assert result.exception
     assert result.exit_code == 2
-    assert 'The given mutually exclusive options cannot be used at the same time' in result.output
+    assert 'Mutually exclusive options from' in result.output
+    assert 'cannot be used at the same time' in result.output
     assert '--bar' in result.output
     assert '--spam' in result.output
 


### PR DESCRIPTION
* Do not use default option group name. An empty group name will not be displayed (#22)
* Slightly edited error messages
* All arguments except `name` in `optgroup` decorator must be keyword-only
