### PR TITLE
PEP 561 support

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,6 +28,10 @@ setup(
     name='click-option-group',
     version=get_version(),
     packages=[PACKAGE_NAME],
+    package_data={
+        PACKAGE_NAME: ["py.typed"]
+    },
+    include_package_data=True,
     python_requires='>=3.6,<4',
     install_requires=[
         'Click>=7.0,<9',


### PR DESCRIPTION
Click itself supports and packages type hints. Adding support here avoids creating noise for users doing type checking and enables them to validate their usages.

https://peps.python.org/pep-0561/#packaging-type-information