### PR TITLE
Add Python 3.13 as experimental

### DIFF
--- a/.github/workflows/step_test.yaml
+++ b/.github/workflows/step_test.yaml
@@ -23,7 +23,7 @@ jobs:
       matrix:
         python-version: [ "3.7", "3.8", "3.9", "3.10", "3.11", "3.12" ]
         include:
-          - python-version: "3.12"
+          - python-version: "3.13"
             experimental: true
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
Removes "experimental" flag for Python 3.12, which is stable, and adds 3.13 as experimental.