### PR TITLE
Update GitHub actions dependencies

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -44,8 +44,8 @@ jobs:
     name: Create release
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: softprops/action-gh-release@v1
+      - uses: actions/checkout@v4
+      - uses: softprops/action-gh-release@v2
         with:
           name: click-option-group ${{ github.ref_name }}
           prerelease: ${{ contains(github.ref, 'rc') }}

--- a/.github/workflows/step_build-wheel.yaml
+++ b/.github/workflows/step_build-wheel.yaml
@@ -18,12 +18,12 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           ref: ${{ inputs.ref }}
       - name: Build package
         run: pipx run build
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           path: dist/*
         if: ${{ inputs.upload }}

--- a/.github/workflows/step_test.yaml
+++ b/.github/workflows/step_test.yaml
@@ -9,9 +9,9 @@ jobs:
     name: Run pre-commit
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
-      - uses: pre-commit/action@v3.0.0
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+      - uses: pre-commit/action@v3.0.1
 
   checks:
     name: Check with Python ${{ matrix.python-version }} ${{ matrix.experimental && '(Experimental)' }}
@@ -26,8 +26,8 @@ jobs:
           - python-version: "3.13"
             experimental: true
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
           allow-prereleases: true


### PR DESCRIPTION
- **actions/checkout:** from v3 to v4
- **softprops/action-gh-release:** from v1 to v2
- **actions/upload-artifact:** from v3 to v4
- **actions/setup-python:** from v4 to v5
- **pre-commit/action:** from v3.0.0 to v3.0.1