### PR TITLE
Remove yapf & Update ruff

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,7 +13,10 @@ repos:
       - id: trailing-whitespace
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.0.284
+    rev: v0.5.5
     hooks:
       - id: ruff
+        name: ruff lint
         args: ["--fix", "--show-fixes"]
+      - id: ruff-format
+        name: ruff format

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,11 +12,6 @@ repos:
       - id: mixed-line-ending
       - id: trailing-whitespace
 
-  - repo: https://github.com/google/yapf
-    rev: v0.40.1
-    hooks:
-      - id: yapf
-
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.0.284
     hooks:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -106,16 +106,6 @@ force_sort_within_sections = true
 force_to_top = ["typing", "pytest"]
 line_length = 120
 
-[tool.yapf]
-based_on_style = "pep8"
-column_limit = 120
-blank_line_before_module_docstring = true
-coalesce_brackets = false
-dedent_closing_brackets = true
-split_arguments_when_comma_terminated = true
-split_before_dict_set_generator = true
-allow_split_before_dict_value = false
-
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,7 +65,11 @@ version.source = "vcs"
 build.hooks.vcs.version-file = "src/click_option_group/_version.py"
 
 [tool.ruff]
+exclude = []
 line-length = 120
+src = ["src"]
+
+[tool.ruff.lint]
 select = [
     "E", "F", "W", # flake8
     "B",           # flake8-bugbear
@@ -95,16 +99,15 @@ extend-ignore = [
     "PT012",   # Block should contain a single simple statement
     "RUF009",  # Too easy to get a false positive
 ]
-src = ["src"]
 unfixable = ["T20", "F841"]
-exclude = []
 
 [tool.isort]
+# Even though ruff is used as formatter, isort profile name is "black".
+profile = "black"
 multi_line_output = 3
 include_trailing_comma = true
 force_sort_within_sections = true
 force_to_top = ["typing", "pytest"]
-line_length = 120
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]

--- a/src/click_option_group/_core.py
+++ b/src/click_option_group/_core.py
@@ -61,8 +61,12 @@ class GroupedOption(click.Option):
         """
         return self.__group
 
-    def handle_parse_result(self, ctx: click.Context, opts: Mapping[str, Any],
-                            args: List[str]) -> Tuple[Any, List[str]]:
+    def handle_parse_result(
+        self,
+        ctx: click.Context,
+        opts: Mapping[str, Any],
+        args: List[str],
+    ) -> Tuple[Any, List[str]]:
         with augment_usage_errors(ctx, param=self):
             if not ctx.resilient_parsing:
                 self.group.handle_parse_result(self, ctx, opts)
@@ -390,7 +394,9 @@ class RequiredMutuallyExclusiveOptionGroup(MutuallyExclusiveOptionGroup):
             group_name = self._group_name_str()
             option_info = self.get_error_hint(ctx)
 
-            msg = f"Missing one of the required mutually exclusive options from {group_name} option group:\n{option_info}"
+            msg = (
+                f"Missing one of the required mutually exclusive options from {group_name} option group:\n{option_info}"
+            )
             raise click.UsageError(
                 msg,
                 ctx=ctx,
@@ -415,7 +421,7 @@ class AllOptionGroup(OptionGroup):
     def handle_parse_result(self, option: GroupedOption, ctx: click.Context, opts: Mapping[str, Any]) -> None:
         option_names = set(self.get_options(ctx))
 
-        if (not option_names.isdisjoint(opts) and option_names.intersection(opts) != option_names):
+        if not option_names.isdisjoint(opts) and option_names.intersection(opts) != option_names:
             group_name = self._group_name_str()
             option_info = self.get_error_hint(ctx)
 

--- a/src/click_option_group/_decorators.py
+++ b/src/click_option_group/_decorators.py
@@ -111,10 +111,9 @@ class _OptGroup:
 
         if not cls:
             cls = OptionGroup
-        else:
-            if not issubclass(cls, OptionGroup):
-                msg = "'cls' must be a subclass of 'OptionGroup' class."
-                raise TypeError(msg)
+        elif not issubclass(cls, OptionGroup):
+            msg = "'cls' must be a subclass of 'OptionGroup' class."
+            raise TypeError(msg)
 
         def decorator(func):
             callback, params = get_callback_and_params(func)
@@ -183,7 +182,7 @@ class _OptGroup:
         the command's help text and exits.
         """
         if not param_decls:
-            param_decls = ("--help", )
+            param_decls = ("--help",)
 
         attrs.setdefault("is_flag", True)
         attrs.setdefault("is_eager", True)

--- a/tests/test_click_option_group.py
+++ b/tests/test_click_option_group.py
@@ -16,7 +16,6 @@ from click_option_group import (
 
 
 def test_basic_functionality_first_api(runner):
-
     @click.command()
     @click.option("--hello")
     @optgroup("Group 1", help="Group 1 description")
@@ -45,7 +44,6 @@ def test_basic_functionality_first_api(runner):
 
 
 def test_noname_group(runner):
-
     @click.command()
     @optgroup()
     @optgroup.option("--foo")
@@ -99,7 +97,6 @@ def test_mix_decl_first_api():
 
 
 def test_missing_group_decl_first_api(runner):
-
     @click.command()
     @click.option("--hello1")
     @optgroup.option("--foo")
@@ -111,7 +108,7 @@ def test_missing_group_decl_first_api(runner):
     result = runner.invoke(cli, ["--help"])
 
     assert result.exception
-    assert TypeError == result.exc_info[0]
+    assert isinstance(result.exception, TypeError)
     assert "Missing option group decorator" in str(result.exc_info[1])
     assert "--foo" in str(result.exc_info[1])
     assert "--bar" in str(result.exc_info[1])
@@ -119,7 +116,7 @@ def test_missing_group_decl_first_api(runner):
     result = runner.invoke(cli, [])
 
     assert result.exception
-    assert TypeError == result.exc_info[0]
+    assert isinstance(result.exception, TypeError)
     assert "Missing option group" in str(result.exc_info[1])
     assert "--foo" in str(result.exc_info[1])
     assert "--bar" in str(result.exc_info[1])
@@ -127,7 +124,7 @@ def test_missing_group_decl_first_api(runner):
     result = runner.invoke(cli, ["--hello1", "hello1"])
 
     assert result.exception
-    assert TypeError == result.exc_info[0]
+    assert isinstance(result.exception, TypeError)
     assert "Missing option group" in str(result.exc_info[1])
     assert "--foo" in str(result.exc_info[1])
     assert "--bar" in str(result.exc_info[1])
@@ -135,7 +132,7 @@ def test_missing_group_decl_first_api(runner):
     result = runner.invoke(cli, ["--foo", "foo"])
 
     assert result.exception
-    assert TypeError == result.exc_info[0]
+    assert isinstance(result.exception, TypeError)
     assert "Missing option group" in str(result.exc_info[1])
     assert "--foo" in str(result.exc_info[1])
     assert "--bar" in str(result.exc_info[1])
@@ -184,7 +181,6 @@ def test_option_group_unexpected_arguments():
 
 
 def test_incorrect_grouped_option_cls():
-
     @click.command()
     @optgroup()
     @optgroup.option("--foo", cls=GroupedOption)
@@ -472,7 +468,6 @@ def test_forbidden_option_attrs(cls):
 
 
 def test_subcommand_first_api(runner):
-
     @click.group()
     @optgroup("Group 1", help="Group 1 description")
     @optgroup.option("--foo")
@@ -677,7 +672,6 @@ def test_subcommand_mix_decl_second_api():
 
 
 def test_command_first_api(runner):
-
     @optgroup("Group 1")
     @optgroup.option("--foo")
     @optgroup.option("--bar")
@@ -697,7 +691,6 @@ def test_command_first_api(runner):
 
 
 def test_hidden_option(runner):
-
     @click.command()
     @click.option("--hello")
     @optgroup("Group 1", help="Group 1 description")
@@ -746,7 +739,9 @@ def test_hidden_option(runner):
     def cli(foo, bar):
         click.echo(f"{foo},{bar}")
 
-    result = runner.invoke(cli, )
+    result = runner.invoke(
+        cli,
+    )
     assert isinstance(result.exception, TypeError)
     assert "Need at least one non-hidden" in str(result.exception)
 
@@ -797,7 +792,6 @@ def test_hidden_option(runner):
     ],
 )
 def test_help_option(runner, param_decls, options, output):
-
     @click.command()
     @optgroup("Help Options")
     @optgroup.help_option(*param_decls)
@@ -817,12 +811,10 @@ def test_help_option(runner, param_decls, options, output):
 
 
 def test_wrapped_functions(runner):
-
     def make_z():
         """A unified option interface for making a `z`."""
 
         def decorator(f):
-
             @optgroup.group("Group xyz")
             @optgroup.option("-x", type=int)
             @optgroup.option("-y", type=int)
@@ -839,7 +831,6 @@ def test_wrapped_functions(runner):
         """A unified option interface for making a `c`."""
 
         def decorator(f):
-
             @optgroup.group("Group abc")
             @optgroup.option("-a", type=int)
             @optgroup.option("-b", type=int)


### PR DESCRIPTION
Updates pre-commit config.

* Remove yapf: Formatting and linting will be handled by ruff, no need for an extra tool.
* Update ruff's pre-commit hook.

Relates to:
- https://github.com/click-contrib/click-option-group/pull/60#issuecomment-2247701917